### PR TITLE
Update external-link dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "external-link": "^1.0.0"
+    "external-link": "^2.0.0"
   }
 }


### PR DESCRIPTION
With new version of external-link, links with target attribute open in new tab as expected
